### PR TITLE
Updated routing in next.config

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,11 +1,15 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  // images: {
-  //   domains: [
-  //     "api.microlink.io",
-  //   ],
-  // },
+  async redirects() {
+    return [
+      {
+        source: "/anonymous",
+        destination: "https://getmsg.netlify.app/sahed",
+        permanent: true,
+      },
+    ];
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
This pull request includes an update to the `next.config.ts` file to add a new redirect configuration.

* [`next.config.ts`](diffhunk://#diff-e3f38f2f0e7ba92f0dd56c086ec5de704229d58d5371e8cc57e43961757d8c7bL4-R12): Added an asynchronous `redirects` function to define a permanent redirect from `/anonymous` to `https://getmsg.netlify.app/sahed`.